### PR TITLE
Adding assets for automated deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# not enabling this yet, so I can set up env vars etc
+
+# This file is sensitive since rules below may be used for restricting who can 
+# make access control changes.
+# /.github/CODEOWNERS @GSA-TTS/FAC-admins
+
+
+# Changes to the following Terraform directory will impact access control in cloud.gov spaces. Any PR involving these files should get a review from someone in FAC-admins.
+# /terraform/management/ @GSA-TTS/FAC-admins

--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -1,0 +1,31 @@
+---
+name: Deploy apps to cloud.gov
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+
+jobs:
+  push-with-creds:
+    name: Deploy to cloud.gov with updated credentials
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      space: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Deploy to cloud.gov
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: ${{ env.space }}
+          push_arguments: -f manifests/manifest-${{ env.space }}.yml --var DB_URI=${{ secrets.DB_URI }}

--- a/.github/workflows/triggers.yml
+++ b/.github/workflows/triggers.yml
@@ -1,0 +1,40 @@
+---
+name: Deploy to cloud.gov
+on:
+  push:
+    branches:
+
+      - main
+      - prod
+    tags:
+      - v1.*
+  pull_request:
+    branches:
+      - main
+      - prod
+  workflow_dispatch: null
+
+jobs:
+  deploy-dev:
+    name: Deploy dev app to cloud.gov
+    if: github.event.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy-apps.yml
+    with:
+      environment: "dev"
+    secrets: inherit
+
+  deploy-staging:
+    name: Deploy staging app to cloud.gov
+    if: github.event.ref == 'refs/heads/prod'
+    uses: ./.github/workflows/deploy-apps.yml
+    with:
+      environment: "staging"
+    secrets: inherit
+
+  deploy-production:
+    name: Deploy production to cloud.gov
+    if: github.event.ref == 'refs/tag/v1.*'
+    uses: ./.github/workflows/deploy-apps.yml
+    with:
+      environment: "production"
+    secrets: inherit

--- a/manifests/manifest-dev.yml
+++ b/manifests/manifest-dev.yml
@@ -11,3 +11,18 @@ applications:
     env:
       PGRST_DB_URI: ((DB_URI))
       PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger-demo
+    instances: 1
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-dev-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-dev-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-dev-postgrest.app.cloud.gov/
+    port: 8080

--- a/manifests/manifest-dev.yml
+++ b/manifests/manifest-dev.yml
@@ -1,0 +1,13 @@
+applications:
+  - name: postgrest
+    instances: 1
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-dev-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon

--- a/manifests/manifest-production.yaml
+++ b/manifests/manifest-production.yaml
@@ -1,5 +1,5 @@
 applications:
-  - name: postgrest-demo
+  - name: postgrest
     instances: 2
     disk_quota: 256M
     memory: 128M
@@ -11,3 +11,18 @@ applications:
     env:
       PGRST_DB_URI: ((DB_URI))
       PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger
+    instances: 2
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-prod-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-prod-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-prod-postgrest.app.cloud.gov/
+    port: 8080

--- a/manifests/manifest-production.yaml
+++ b/manifests/manifest-production.yaml
@@ -1,0 +1,13 @@
+applications:
+  - name: postgrest-demo
+    instances: 2
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-prod-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon

--- a/manifests/manifest-staging.yaml
+++ b/manifests/manifest-staging.yaml
@@ -11,3 +11,18 @@ applications:
     env:
       PGRST_DB_URI: ((DB_URI))
       PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger-demo
+    instances: 1
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-dev-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-dev-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-dev-postgrest.app.cloud.gov/
+    port: 8080

--- a/manifests/manifest-staging.yaml
+++ b/manifests/manifest-staging.yaml
@@ -1,0 +1,13 @@
+applications:
+  - name: postgrest
+    instances: 1
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-staging-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon


### PR DESCRIPTION
[#860](https://github.com/GSA-TTS/FAC/issues/860)
Successfully deploys to dev from GitHub triggers.

Creates manifest for dev, staging, and prod.
Follows the same logic as our existing [branching strategy](https://github.com/GSA-TTS/FAC/blob/main/docs/branching.md).

Does not run the tests since the views are changing etc. 

## Setting up variables:
The required variables for dev deployment are set up. The plan is to remake the databases with Terraform, that has happened in dev but not staging or prod. I can add the DB connection variables after the next deploy in the respective environments.
